### PR TITLE
More control over managing controllers, updated docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This puppet module generate facts and provides types and providers to manage LSI
 
 This module makes use of storcli. The package needs to be available from some repository to be installed.
 
+If running on a Dell server, the module will look to use perccli if it exists. The perccli package will need to be installed separately from this module.
+
 ## Usage
 
 ```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -32,6 +32,7 @@ The following parameters are available in the `storcli` class:
 * [`package_ensure`](#package_ensure)
 * [`link_storcli_to`](#link_storcli_to)
 * [`configure_settings`](#configure_settings)
+* [`controller_manage_rebuild`](#controller_manage_rebuild)
 * [`controller_autorebuild`](#controller_autorebuild)
 * [`controller_rebuildrate`](#controller_rebuildrate)
 * [`sync_time_to_controllers`](#sync_time_to_controllers)
@@ -40,6 +41,7 @@ The following parameters are available in the `storcli` class:
 * [`controller_ncq`](#controller_ncq)
 * [`controller_cacheflushinterval`](#controller_cacheflushinterval)
 * [`controller_bootwithpinnedcache`](#controller_bootwithpinnedcache)
+* [`controller_manage_alarm`](#controller_manage_alarm)
 * [`controller_alarm`](#controller_alarm)
 * [`controller_smartpollinterval`](#controller_smartpollinterval)
 * [`controller_patrolread_mode`](#controller_patrolread_mode)
@@ -84,6 +86,13 @@ Data type: `Boolean`
 
 Should this class be able to enforce configuration settings on the controllers?
 If you've got multiple controllers which should have different configs, you'll want to set this to false.
+Default value: true
+
+##### <a name="controller_manage_rebuild"></a>`controller_manage_rebuild`
+
+Data type: `Boolean`
+
+Should this class manage how the controller automatically rebuilds arrays
 Default value: true
 
 ##### <a name="controller_autorebuild"></a>`controller_autorebuild`
@@ -142,6 +151,14 @@ Data type: `Boolean`
 
 Continue booting with data stuck in cache?
 Default value: false
+
+##### <a name="controller_manage_alarm"></a>`controller_manage_alarm`
+
+Data type: `Boolean`
+
+Should this class manage the alarm on the controller
+Set to false if storcli cannot manage the alarm on a particular controller
+Default value: true
 
 ##### <a name="controller_alarm"></a>`controller_alarm`
 
@@ -223,6 +240,7 @@ Configure the storage controllers with the specified settings
 The following parameters are available in the `storcli::configure` class:
 
 * [`configure_settings`](#configure_settings)
+* [`controller_manage_rebuild`](#controller_manage_rebuild)
 * [`controller_autorebuild`](#controller_autorebuild)
 * [`controller_rebuildrate`](#controller_rebuildrate)
 * [`sync_time_to_controllers`](#sync_time_to_controllers)
@@ -231,6 +249,7 @@ The following parameters are available in the `storcli::configure` class:
 * [`controller_ncq`](#controller_ncq)
 * [`controller_cacheflushinterval`](#controller_cacheflushinterval)
 * [`controller_bootwithpinnedcache`](#controller_bootwithpinnedcache)
+* [`controller_manage_alarm`](#controller_manage_alarm)
 * [`controller_alarm`](#controller_alarm)
 * [`controller_smartpollinterval`](#controller_smartpollinterval)
 * [`controller_patrolread_mode`](#controller_patrolread_mode)
@@ -251,6 +270,15 @@ If you've got multiple controllers which should have different configs, you'll w
 Default value: true
 
 Default value: `$storcli::configure_settings`
+
+##### <a name="controller_manage_rebuild"></a>`controller_manage_rebuild`
+
+Data type: `Any`
+
+Should this class manage how the controller automatically rebuilds arrays
+Default value: true
+
+Default value: `$storcli::controller_manage_rebuild`
 
 ##### <a name="controller_autorebuild"></a>`controller_autorebuild`
 
@@ -324,6 +352,16 @@ Continue booting with data stuck in cache?
 Default value: false
 
 Default value: `$storcli::controller_bootwithpinnedcache`
+
+##### <a name="controller_manage_alarm"></a>`controller_manage_alarm`
+
+Data type: `Any`
+
+Should this class manage the alarm on the controller
+Set to false if storcli cannot manage the alarm on a particular controller
+Default value: true
+
+Default value: `$storcli::controller_manage_alarm`
 
 ##### <a name="controller_alarm"></a>`controller_alarm`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -7,6 +7,7 @@ storcli::link_storcli_to: /usr/local/sbin
 
 storcli::configure_settings: true
 
+storcli::controller_manage_rebuild: true
 storcli::controller_autorebuild: true
 storcli::controller_rebuildrate: 60
 
@@ -18,6 +19,7 @@ storcli::controller_ncq: true
 storcli::controller_cacheflushinterval: 4
 storcli::controller_bootwithpinnedcache: false
 
+storcli::controller_manage_alarm: true
 storcli::controller_alarm: true
 storcli::controller_bbu_learndelayinterval: 0
 storcli::controller_smartpollinterval: 60

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,10 @@
 #   If you've got multiple controllers which should have different configs, you'll want to set this to false.
 #   Default value: true
 #
+# @param controller_manage_rebuild
+#   Should this class manage how the controller automatically rebuilds arrays
+#   Default value: true
+#
 # @param controller_autorebuild
 #   Should this controller automatically rebuild arrays
 #   Default value: true
@@ -54,6 +58,11 @@
 # @param controller_bootwithpinnedcache
 #   Continue booting with data stuck in cache?
 #   Default value: false
+#
+# @param controller_manage_alarm
+#   Should this class manage the alarm on the controller
+#   Set to false if storcli cannot manage the alarm on a particular controller
+#   Default value: true
 #
 # @param controller_alarm
 #   Sound alarm when a disk is bad?
@@ -98,12 +107,13 @@
 #
 class storcli (
   # Hiera can convert facts to strings, but we really want a bool
-  # https://tickets.puppetlabs.com/browse/PUP-10259 
+  # https://tickets.puppetlabs.com/browse/PUP-10259
   Variant[Boolean, Enum['true', 'false']] $package_manage,
   Array[String] $package_name,
   String        $package_ensure,
   Stdlib::Absolutepath $link_storcli_to,
   Boolean         $configure_settings,
+  Boolean         $controller_manage_rebuild,
   Boolean         $controller_autorebuild,
   Integer[0, 100] $controller_rebuildrate,
   Boolean         $sync_time_to_controllers,
@@ -112,6 +122,7 @@ class storcli (
   Boolean         $controller_ncq,
   Integer[1]      $controller_cacheflushinterval,
   Boolean         $controller_bootwithpinnedcache,
+  Boolean         $controller_manage_alarm,
   Boolean         $controller_alarm,
   Integer[0, 65535]             $controller_smartpollinterval,
   Enum['auto', 'manual', 'off'] $controller_patrolread_mode,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "trunet-storcli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Wagner Sartori Junior",
   "summary": "Puppet module to generate facts with types and providers to manage LSI MegaRAID controllers",
   "license": "Apache-2.0",

--- a/spec/classes/configure_spec.rb
+++ b/spec/classes/configure_spec.rb
@@ -54,6 +54,7 @@ describe 'storcli::configure' do
         let(:params) do
           {
             'configure_settings' => true,
+            'controller_manage_rebuild' => true,
             'controller_autorebuild' => true,
           }
         end
@@ -70,6 +71,7 @@ describe 'storcli::configure' do
         let(:params) do
           {
             'configure_settings' => true,
+            'controller_manage_rebuild' => true,
             'controller_autorebuild' => false,
           }
         end
@@ -86,6 +88,7 @@ describe 'storcli::configure' do
         let(:params) do
           {
             'configure_settings' => true,
+            'controller_manage_rebuild' => true,
             'controller_rebuildrate' => 50,
           }
         end
@@ -242,6 +245,7 @@ describe 'storcli::configure' do
         let(:params) do
           {
             'configure_settings' => true,
+            'controller_manage_alarm' => true,
             'controller_alarm' => true,
           }
         end
@@ -258,6 +262,7 @@ describe 'storcli::configure' do
         let(:params) do
           {
             'configure_settings' => true,
+            'controller_manage_alarm' => true,
             'controller_alarm' => false,
           }
         end


### PR DESCRIPTION
Hi - thanks for merging yesterday's PR

Please find this PR which allow us more control over the many controllers which don't allow managing alarms and rebuild rates at all:
* allow override flags to manage rebuilds and alarms even at all
* add some notes to the README about Dell using perccli
* bump version

I have run
* pdk validate
* pdk test unit (with the new variables)
* pdk bundle exec puppet strings generate --format markdown --out REFERENCE.md